### PR TITLE
Changing back to port 5000 (Flask default)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ RUN pip install -r /app/requirments.txt
 
 
 ENV FLASK_APP=lanternfish.py
-ENV FLASK_RUN_PORT=6000  
+ENV FLASK_RUN_PORT=5000  
 
-EXPOSE 6000
+EXPOSE 5000
 
 ENTRYPOINT  ["flask", "run", "--host=0.0.0.0"]


### PR DESCRIPTION
This PR switches back to using port 5000.  This is useful because 

1. The flask default port is 5000
2. X11 uses port 6000
3. The rest of the world wasn't already running something else on 5000 like I was.

The FLASK_RUN_PORT env var seems redundant.  I have opted to leave this in case a user wants to change the port but is not familiar with flask.

